### PR TITLE
Fix openconnect_pkgs not expanded

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,13 +7,13 @@
 - name: Install the packages in Redhat derivates
   tags: openconnect
   yum: name={{ item }} state=present
-  with_items: openconnect_pkgs
+  with_items: "{{ openconnect_pkgs }}"
   when: ansible_os_family == 'RedHat'
 
 - name: Install the mysql packages in Debian derivates
   tags: openconnect
   apt: name={{ item }} state=present update_cache=yes cache_valid_time=600
-  with_items: openconnect_pkgs
+  with_items: "{{ openconnect_pkgs }}"
   environment:
     # prevent openconnect from autostart after installation
     RUNLEVEL: 1


### PR DESCRIPTION
This is required in recent Ansible versions.
Tested under Ansible 2.3